### PR TITLE
Add Quiptree to Sample Apps section.

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,3 +26,4 @@ This is the official repository for the [Quip API](https://quip.com/api/).
 * [`twitterbot`](samples/twitterbot): Post Twitter messages to a Quip thread via the Twitter streaming API. _Python on the command line_
 * [`webhooks`](samples/webhooks): Inbound [Webhook](http://en.wikipedia.org/wiki/Webhook) support for posting GitHub, Crashlytics, PagerDuty and other service notifications to threads. _Python on App Engine_
 * [`wordpress`](samples/wordpress): Publish Quip documents to [WordPress](http://wordpress.org/). _Python on the command line_
+* [`quiptree`](https://github.com/kwent/quiptree): Browser extension to display Quip folders and files in tree format. _Javascript on Browser Extension Engine_

--- a/samples/README.md
+++ b/samples/README.md
@@ -6,3 +6,4 @@ Quip API Sample Apps
 * [`twitterbot`](twitterbot): Post Twitter messages to a Quip thread via the Twitter streaming API. _Python on the command line_
 * [`webhooks`](webhooks): Inbound [Webhook](http://en.wikipedia.org/wiki/Webhook) support for posting GitHub, Crashlytics, PagerDuty and other service notifications to threads. _Python on App Engine_
 * [`wordpress`](wordpress): Publish Quip documents to [WordPress](http://wordpress.org/). _Python on the command line_
+* [`quiptree`](https://github.com/kwent/quiptree): Browser extension to display Quip folders and files in tree format. _Javascript on Browser Extension Engine_


### PR DESCRIPTION
Browser extension to display Quip folders and files in tree format: https://github.com/kwent/quiptree