### PR TITLE
Set system default encoding to UTF-8

### DIFF
--- a/python/quip.py
+++ b/python/quip.py
@@ -36,6 +36,10 @@ import time
 import urllib
 import urllib2
 import xml.etree.cElementTree
+import sys  
+
+reload(sys)  
+sys.setdefaultencoding('utf8')
 
 
 class QuipClient(object):

--- a/samples/baqup/main.py
+++ b/samples/baqup/main.py
@@ -28,6 +28,10 @@ import shutil
 import urllib2
 import xml.etree.cElementTree
 import xml.sax.saxutils
+import sys  
+
+reload(sys)  
+sys.setdefaultencoding('utf8')
 
 import quip
 


### PR DESCRIPTION
This resolves the following error when encountering a non-ascii character:

```
Traceback (most recent call last):
  File "main.py", line 257, in <module>
    main()
  File "main.py", line 69, in main
    _run_backup(client, output_directory, args.root_folder_id)
  File "main.py", line 81, in _run_backup
    client, output_directory, 0)
  File "main.py", line 116, in _descend_into_folder
    client, folder_output_path, depth + 1)
  File "main.py", line 116, in _descend_into_folder
    client, folder_output_path, depth + 1)
  File "main.py", line 116, in _descend_into_folder
    client, folder_output_path, depth + 1)
  File "main.py", line 116, in _descend_into_folder
    client, folder_output_path, depth + 1)
  File "main.py", line 119, in _descend_into_folder
    _backup_thread(thread, client, folder_output_path, depth + 1)
  File "main.py", line 139, in _backup_thread
    image_output_path = os.path.join(output_directory, image_filename)
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/posixpath.py", line 73, in join
    path += '/' + b
UnicodeDecodeError: 'ascii' codec can't decode byte 0xd0 in position 1: ordinal not in range(128)
```