### PR TITLE
Add missing parameter to new_document function

### DIFF
--- a/python/quip.py
+++ b/python/quip.py
@@ -293,7 +293,7 @@ class QuipClient(object):
             "member_ids": ",".join(member_ids),
         })
 
-    def new_document(self, content, format="html", title=None, member_ids=[]):
+    def new_document(self, content, type="document", format="html", title=None, member_ids=[]):
         """Creates a new document from the given content.
 
         To create a document in a folder, include the folder ID in the list
@@ -308,6 +308,7 @@ class QuipClient(object):
             "content": content,
             "format": format,
             "title": title,
+            "type": type,
             "member_ids": ",".join(member_ids),
         })
 


### PR DESCRIPTION
Add missing "type" parameter, listed at https://salesforce.quip.com/dev/automation/documentation#document-post,  so you can create spreadsheets or documents using quip api