### PR TITLE
remove outdated sample app.

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,3 @@ This is the official repository for the [Quip Automation API](https://quip.com/a
 * [`webhooks`](samples/webhooks): Inbound [Webhook](http://en.wikipedia.org/wiki/Webhook) support for posting GitHub, Crashlytics, PagerDuty and other service notifications to threads. _Python on App Engine_
 * [`wordpress`](samples/wordpress): Publish Quip documents to [WordPress](http://wordpress.org/). _Python on the command line_
 * [`websocket`](samples/websocket): Receive messages from Quip in real time. _Python on the command line_
-
-### Community
-
-* [`quiptree`](https://github.com/kwent/quiptree): Browser extension to display Quip folders and files in tree format. _Javascript on Browser Extension Engine_

--- a/samples/README.md
+++ b/samples/README.md
@@ -8,7 +8,3 @@ Quip API Sample Apps
 * [`wordpress`](wordpress): Publish Quip documents to [WordPress](http://wordpress.org/). _Python on the command line_
 * [`websocket`](websocket): Receive messages from Quip in real time. _Python on the command line_
 * [`events-api`](events-api): Examine, audit, and quarantine Quip content in real-time based on the Events API feed. _Python on the command line_
-
-# Community Samples
-
-* [`quiptree`](https://github.com/kwent/quiptree): Browser extension to display Quip folders and files in tree format. _Javascript on Browser Extension Engine_


### PR DESCRIPTION
the app describes itself as "DEPRECATED and NOT maintained anymore since this feature is built-in in Quip."
