### PR TITLE
Added add_thread_members_by_access_level()

### DIFF
--- a/python/quip.py
+++ b/python/quip.py
@@ -272,6 +272,22 @@ class QuipClient(object):
             "member_ids": ",".join(member_ids),
         })
 
+    def add_thread_members_by_access_level(self, thread_id, full=None,
+                                           edit=None, comment=None,
+                                           view=None):
+        """Adds the given folder or userIDs to the given thread."""
+        return self._fetch_json("threads/add-members", post_data={
+            "thread_id": thread_id,
+            "member_ids_by_access_level": json.dumps([
+                {"access_level": 0,
+                 "member_ids": [",".join(full)] if full else []},
+                {"access_level": 1,
+                 "member_ids": [",".join(edit)] if edit else []},
+                {"access_level": 2,
+                 "member_ids": [",".join(comment)] if comment else []},
+                {"access_level": 3,
+                 "member_ids": [",".join(view)] if view else []}])})
+
     def delete_thread(self, thread_id):
         """Deletes the thread with the given thread id or secret"""
         return self._fetch_json("threads/delete", post_data={

--- a/python/quip.py
+++ b/python/quip.py
@@ -280,13 +280,13 @@ class QuipClient(object):
             "thread_id": thread_id,
             "member_ids_by_access_level": json.dumps([
                 {"access_level": 0,
-                 "member_ids": [",".join(full)] if full else []},
+                 "member_ids": full or []},
                 {"access_level": 1,
-                 "member_ids": [",".join(edit)] if edit else []},
+                 "member_ids": edit or []},
                 {"access_level": 2,
-                 "member_ids": [",".join(comment)] if comment else []},
+                 "member_ids": comment or []},
                 {"access_level": 3,
-                 "member_ids": [",".join(view)] if view else []}])})
+                 "member_ids": view or []}])})
 
     def delete_thread(self, thread_id):
         """Deletes the thread with the given thread id or secret"""


### PR DESCRIPTION
The current python library only supports add_thread_members() where all members will get added with full access. The pull request implements add_thread_members_by_access_level() which will allow for the addition of members with different access levels - utilizing the member_ids_by_access_level variant of the /1/threads/add-members API.