### PR TITLE
Update quip.py

### DIFF
--- a/python/quip.py
+++ b/python/quip.py
@@ -644,7 +644,7 @@ class QuipClient(object):
 
     def get_row_ids(self, row_tree):
         """Returns the ids of items in the given row `ElementTree`."""
-        return [x.attrib["id"] for x in row_tree]
+        return [x.get("id") for x in row_tree]
 
     def get_spreadsheet_header_items(self, spreadsheet_tree):
         """Returns the header row in the given spreadsheet `ElementTree`."""


### PR DESCRIPTION
'.attrib['id']' throws an error: "KeyError: 'id' ". Variable 'row' is of type <class 'xml.etree.ElementTree.Element'>.By the docs: https://docs.python.org/3/library/xml.etree.elementtree.html we should use x.get("id")