### PR TITLE
fix multiline cell issue #67

### DIFF
--- a/python/quip.py
+++ b/python/quip.py
@@ -709,7 +709,7 @@ class QuipClient(object):
                 if images:
                     data["content"] = images[0].attrib.get("src")
                 else:
-                    data["content"] = list(cell.itertext())[0].replace(
+                    data["content"] = " ".join(list(cell.itertext())[:-1]).replace(
                         u"\u200b", "")
                 style = cell.attrib.get("style")
                 if style and "background-color:#" in style:


### PR DESCRIPTION
Fixes an issue where cells with multiple lines of data only return the first line. The fix joins all the lines in the cell with spaces and returns the string.

# Problem

The original way is to choose the first value in the cell to ignore the `\n\n` that is returned by the API. When there are multiple lines of data this chooses the first string and returns the string thereby creating this issue.

# Fix

The fix is to ignore the last string instead of selecting the first string. This way, cells with multiple lines will return the entire data.

# Design decision taken

The fix will join multiple lines using whitespace. I understand this might not be the best way to do this and I am seeking some guidance in this case from the maintainers to ensure proper compatibility.