### PR TITLE
Add edit history support (quip.py)

### DIFF
--- a/python/quip.py
+++ b/python/quip.py
@@ -220,7 +220,7 @@ class QuipClient(object):
         """Returns the teams for the user corresponding to our access token."""
         return self._fetch_json("teams/current")
 
-    def get_messages(self, thread_id, max_created_usec=None, count=None):
+    def get_messages(self, thread_id, max_created_usec=None, count=None, message_type=None):
         """Returns the most recent messages for the given thread.
 
         To page through the messages, use max_created_usec, which is the
@@ -228,10 +228,13 @@ class QuipClient(object):
 
         count should be an integer indicating the number of messages you
         want returned. The maximum is 100.
+        
+        set message_type to "edit" to retrieve document edit messages. Regular
+        messages are returned by default.
         """
         return self._fetch_json(
             "messages/" + thread_id, max_created_usec=max_created_usec,
-            count=count)
+            count=count, message_type=message_type)
 
     def new_message(self, thread_id, content=None, **kwargs):
         """Sends a message on the given thread.


### PR DESCRIPTION
Fixes an issue where `get_messages()` can only retrieve "regular" messages, not "edit" messages. Without this fix, I don't think quip.py can retrieve the edit history of a thread (please let me know if there is another way).

I'm not sure if there's a better name for "regular" messages. That's what the [official API documentation](https://quip.com/dev/automation/documentation/current#operation/getRecentMessages) calls them.