### PR TITLE
support V2 API

### DIFF
--- a/python/quip.py
+++ b/python/quip.py
@@ -812,7 +812,10 @@ class QuipClient(object):
                     for k, v in args.items() if v or isinstance(v, int))
 
     def _url(self, path, **args):
-        url = self.base_url + "/1/" + path
+        ver = args.pop("ver", 1)
+        if ver not in [1, 2]:
+            raise ValueError("Invalid API version: " + str(ver))
+        url = self.base_url + f"/{ver}/" + path
         args = self._clean(**args)
         if args:
             url += "?" + urlencode(args)


### PR DESCRIPTION
Accept a parameter named "ver" to allow function choice which version of the API going to be used. Limited to use V1 as default and allow V2 as optional.

Refer to: https://quip.com/dev/automation/documentation/current#operation/getThreadFoldersV2