### PR TITLE
Adding slack.json file to enable checkpoint for the repo

### DIFF
--- a/slack.json
+++ b/slack.json
@@ -1,0 +1,8 @@
+{
+    "checkpoint": {
+      "checkpoint_ready_check": false,
+      "notifications": {
+        "dm": false
+      }
+    }
+  }


### PR DESCRIPTION
Background / Why?
This PR adds slack.json file to slack-android-ng repo to enable checkpoint for the repo
(enabling checkpoint for github/tinyspeck repo for Better Engineering Metrics Tableau data source)
Ticket(s): None
https://jira.tinyspeck.com/browse/ENGOPS-7615

Feature flag(s): None

Summary
https://jira.tinyspeck.com/browse/ENGOPS-7615

Testing
https://salesforce.enterprise.slack.com/docs/T024BE7LD/F07SSHNH6C9

[Quip Pull Requests & flow](https://corp.quip.com/d10wAXgStV2e) | [Quip Emergency PR Approval Docs](https://corp.quip.com/m3H0AWbaDQha)